### PR TITLE
모으기 페이지 틀 생성

### DIFF
--- a/src/pages/Collect/AboutChallenge.jsx
+++ b/src/pages/Collect/AboutChallenge.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const AboutChallenge = () => {
+  return <div>챌린지 관련</div>;
+};
+
+export default AboutChallenge;

--- a/src/pages/Collect/Chatting.jsx
+++ b/src/pages/Collect/Chatting.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Chatting = () => {
+  return <div></div>;
+};
+
+export default Chatting;

--- a/src/pages/Collect/Collect.jsx
+++ b/src/pages/Collect/Collect.jsx
@@ -1,10 +1,38 @@
 // 모으기 페이지 제작 예정
-import React from "react";
+import React, { useState } from "react";
 import styles from "./Collect.module.css";
+import Header from "../../components/Header/Header";
+import BottomBar from "../../components/BottomBar/BottomBar";
+import AboutChallenge from "./AboutChallenge";
+import Chatting from "./Chatting";
 
 const Collect = () => {
   const pageName = "모으기";
-  return <div>Collect</div>;
+  const [isChatting, setIsChatting] = useState(false);
+
+  return (
+    <div className={styles.CollectPageContainer}>
+      <Header pageName={pageName} />
+      <nav className={styles.navTab}>
+        <button
+          onClick={() => setIsChatting(false)}
+          className={!isChatting ? styles.activeTab : styles.inactiveTab}
+        >
+          챌린지
+        </button>
+        <button
+          onClick={() => setIsChatting(true)}
+          className={isChatting ? styles.activeTab : styles.inactiveTab}
+        >
+          채팅
+        </button>
+      </nav>
+      <div className={styles.MainArea}>
+        {!isChatting ? <AboutChallenge /> : <Chatting />}
+      </div>
+      <BottomBar pageName={pageName} />
+    </div>
+  );
 };
 
 export default Collect;

--- a/src/pages/Collect/Collect.module.css
+++ b/src/pages/Collect/Collect.module.css
@@ -1,0 +1,50 @@
+.CollectPageContainer {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+.navTab {
+  display: flex;
+  width: inherit;
+}
+.navTab .activeTab {
+  display: flex;
+  flex: 1;
+  padding: 13px 57px;
+  justify-content: center;
+  align-items: center;
+  border-bottom: 6px solid #5e5e5e;
+  background: #fff;
+  color: #454545;
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+}
+.navTab .inactiveTab {
+  display: flex;
+  flex: 1;
+  padding: 13px 57px;
+  justify-content: center;
+  align-items: center;
+  background: #fff;
+  color: #454545;
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}
+.MainArea {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  background-color: #f8f8f8;
+  overflow: auto;
+  display: flex;
+  align-items: center;
+  padding-bottom: 80px;
+}

--- a/src/pages/MyRecord/MyRecord.jsx
+++ b/src/pages/MyRecord/MyRecord.jsx
@@ -6,27 +6,28 @@ import MyChallenge from "./MyChallenge";
 
 const MyRecord = () => {
   const pageName = "나의 기록";
-  const [isClicked, setIsClicked] = useState(0);
+  // 탭바 boolean으로 수정
+  const [isChallenge, setIsChallenge] = useState(false);
 
   return (
     <div className={styles.MyRecordePageContainer}>
       <Header pageName={pageName} />
       <nav className={styles.navTab}>
         <button
-          onClick={() => setIsClicked(0)}
-          className={isClicked === 0 ? styles.activeTab : styles.inactiveTab}
+          onClick={() => setIsChallenge(false)}
+          className={!isChallenge ? styles.activeTab : styles.inactiveTab}
         >
           나의 소비
         </button>
         <button
-          onClick={() => setIsClicked(1)}
-          className={isClicked === 1 ? styles.activeTab : styles.inactiveTab}
+          onClick={() => setIsChallenge(true)}
+          className={isChallenge ? styles.activeTab : styles.inactiveTab}
         >
           챌린지
         </button>
       </nav>
       <div className={styles.wrapper}>
-        {isClicked === 0 ? <MyConsumption /> : <MyChallenge />}
+        {!isChallenge ? <MyConsumption /> : <MyChallenge />}
       </div>
     </div>
   );


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/26757739-a61b-4d3c-808d-cd7ca5d3d058)

챌린지, 채팅 각각 구현하면 됩니다.
나의 소비 부분 헤더, 상단 탭바 고정되도록 스타일링 수정했습니다.
나의 소비 부분 살짝 수정했는데 신경안쓰셔도 됩니다!